### PR TITLE
Field/model keeps invalid state after setting an external validation message

### DIFF
--- a/src/config/ngModelDecorator.js
+++ b/src/config/ngModelDecorator.js
@@ -97,7 +97,7 @@
                                 if (ngModelCtrl.externalErrors) {
                                     var errorCollection = ngModelCtrl.$error || ngModelCtrl.$errors;
                                     angular.forEach(ngModelCtrl.externalErrors, function (value, key) {
-                                        errorCollection[key] = true;
+                                        delete errorCollection[key];
                                     });
 
                                     ngModelCtrl.externalErrors = {};


### PR DESCRIPTION
After setting an external validation message using setExternalValidation without a key (server supplies error message only), the validation message disappears after changing the field as expected. However, if you make another change to that same field, a validation error re-occurs. 

I believe this behaviour comes from not properly unsetting the error from the model error collection.