### PR TITLE
Improved error reporting when a custom error override is specified, but not translated

### DIFF
--- a/src/services/defaultErrorMessageResolver.js
+++ b/src/services/defaultErrorMessageResolver.js
@@ -161,7 +161,9 @@ function DefaultErrorMessageResolverFn($q, $http) {
           errMsg = angular.autoValidate.errorMessages[currentCulture][messageTypeOverride];
         }
 
-        if (errMsg === undefined) {
+        if (errMsg === undefined && messageTypeOverride !== undefined) {
+          errMsg = angular.autoValidate.errorMessages[currentCulture].defaultMsg.format(messageTypeOverride);
+        } else if (errMsg === undefined) {
           errMsg = angular.autoValidate.errorMessages[currentCulture].defaultMsg.format(errorType);
         }
 


### PR DESCRIPTION
The defaultError message would be used when a custom error directive was found, but not defined in strings / translations. This would show the original validator name, instead of the actual specified error override. 

This caused me (and possibly other people) to get confused as to whether the custom error mechanism was working at all, or I was doing something wrong.

The pull request fixes this problem by using the found `messageTypeOverride` key.