### PR TITLE
Change the default language to 'default'

### DIFF
--- a/src/services/defaultErrorMessageResolver.js
+++ b/src/services/defaultErrorMessageResolver.js
@@ -14,7 +14,7 @@ angular.autoValidate = angular.autoValidate || {
   errorMessages: {}
 };
 
-angular.autoValidate.errorMessages['en-us'] = angular.autoValidate.errorMessages['en-gb'] = {
+angular.autoValidate.errorMessages['default'] = {
   defaultMsg: 'Please add error message for {0}',
   email: 'Please enter a valid email address',
   minlength: 'Please enter at least {0} characters',
@@ -29,7 +29,7 @@ angular.autoValidate.errorMessages['en-us'] = angular.autoValidate.errorMessages
 };
 
 function DefaultErrorMessageResolverFn($q, $http) {
-  var currentCulture = 'en-gb',
+  var currentCulture = 'default',
 
     i18nFileRootPath = 'js/angular-auto-validate/dist/lang',
 


### PR DESCRIPTION
It make not necessary clear the cache using
angular.autoValidate.errorMessages = {};
when you want to use remote JSON file ‘en-us’ or ‘en-gb’.