### PR TITLE
Improve german translations

### DIFF
--- a/src/lang/jcs-auto-validate_de-de.json
+++ b/src/lang/jcs-auto-validate_de-de.json
@@ -1,11 +1,11 @@
 {
     "defaultMsg": "Bitte eine Fehlermeldung für {0} hinzufügen.",
-    "email": "Bitte eine gültige EMail-Adresse eingeben.",
+    "email": "Bitte eine gültige E-Mail-Adresse eingeben.",
     "minlength": "Bitte mindestens {0} Zeichen eingeben.",
     "maxlength": "Es wurden mehr Zeichen als zulässig eingegeben (maximal {0}).",
     "min": "Bitte eine Zahl von mindestens {0} eingeben.",
     "max": "Bitte eine Zahl von maximal {0} eingeben.",
-    "required": "Hier wird eine Eigabe erwartet.",
+    "required": "Dieses Feld bitte ausfüllen.",
     "date": "Bitte ein gültiges Datum eingeben.",
     "pattern": "Die Eingabe sollte diesem Muster entsprechen: {0}",
     "number": "Bitte eine gültige Zahl eingeben.",


### PR DESCRIPTION
I improved two translations:
 - `email`: E-Mail-Adresse is the official (and most common) spelling
 - `required`: The current message sounds unfriendly in comparison to the others

Unfortunately the translations for `min` and `max` sound pretty weird. In german you would say "Please enter a number greater than {0}-1". Is there any possibility to include an expression like `({0} - 1)` into an error message?