### PR TITLE
Change in Process Element condition to improve IE10 Performance

### DIFF
--- a/src/services/validationManager.js
+++ b/src/services/validationManager.js
@@ -181,7 +181,7 @@ function ValidationManagerFn(validator, elementUtils) {
 
       // IE8 holds the child controls collection in the all property
       // Firefox in the elements and chrome as a child iterator
-      angular.forEach((frmElement[0].all || frmElement[0].elements) || frmElement[0], function (ctrlElement) {
+      angular.forEach((frmElement[0].elements || frmElement[0].all) || frmElement[0], function (ctrlElement) {
         processElement(ctrlElement, true, clonedOptions);
       });
 


### PR DESCRIPTION
IE10 FORM DOM contains both all and elements attributes. Elements contains the relevant elements for validation and all contains many other elements not required for the validation. Since the condition uses all attribute first, it causes performance issues in IE10 with unnecessary looping. Change in condition order ensures efficiency in IE10. IE11 onwards, all attribute is null and similar issues is not found.