### PR TITLE
Add support for transclude on form

### DIFF
--- a/src/directives/autoValidateFormOptions.js
+++ b/src/directives/autoValidateFormOptions.js
@@ -35,7 +35,6 @@ angular.module('jcs-autoValidate').directive('form', [
     return {
       restrict: 'E',
       require: 'form',
-      priority: 9999,
       compile: function () {
         return {
           pre: function (scope, element, attrs, ctrl) {

--- a/tests/directives/autoValidateFormOptions.spec.js
+++ b/tests/directives/autoValidateFormOptions.spec.js
@@ -8,7 +8,16 @@
       $rootScope.$digest();
     };
 
-  beforeEach(module('jcs-autoValidate'));
+  var transcludeModule = angular.module("transclude-test", []);
+  transcludeModule.directive("transcludeExample", function () {
+    return {
+      scope: false,
+      transclude: true,
+      template: '<form ng-if="!editMode" ng-transclude></form>'
+    };
+  });
+
+  beforeEach(module('jcs-autoValidate', transcludeModule.name));
 
   describe('autoValidateFormOptions', function () {
     beforeEach(inject(function ($injector) {
@@ -23,9 +32,15 @@
     });
 
     it('should be defined', function () {
-      compileElement('<form name="test""></form>');
+      compileElement('<form name="test"></form>');
 
       expect(element.controller('form').autoValidateFormOptions).to.exist;
+    });
+
+    it('should not fail when form uses transclude', function () {
+      compileElement("<transclude-example>My Content</transclude-example>");
+
+      expect(element.find('form').controller('form').autoValidateFormOptions).to.exists;
     });
 
     describe('disableDynamicValidation', function () {


### PR DESCRIPTION
Remove the explicit priority to support ng-transcludes on form elements.
It is unclear why the explict priority is needed? All tests are running
even if the priority is being removed.

Probably fixes #67